### PR TITLE
Add a plugin file so this can be automatically loaded by zgen, antigen and oh-my-zsh

### DIFF
--- a/bash-my-aws.plugin.zsh
+++ b/bash-my-aws.plugin.zsh
@@ -1,0 +1,5 @@
+# Do some minimal hoop-jumping so this repo can be loaded as a ZSH plugin
+
+# All we need to do is figure out where we were cloned and source
+# the cloudformation-functions file
+source $(dirname $0)/cloudformation-functions


### PR DESCRIPTION
ZSH frameworks like [zgen](https://github.com/tarjoilija/zgen), [antigen](https://github.com/zsh-users/antigen) and [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) have a standard plugin file naming convention that originated in oh-my-zsh.

Having a plugin.zsh file lets framework users use these aliases as easily as adding `antigen bundle realestate-com-au/bash-my-aws` (for antigen users) or `zgen load realestate-com-au/bash-my-aws` for zgen users and then the framework will automatically clone the repo and source the plugin file.