### PR TITLE
Uses effective user id as default user for cf_asg_instance_ssh

### DIFF
--- a/cloudformation-functions
+++ b/cloudformation-functions
@@ -241,7 +241,7 @@ cf_asg_instances() {
 cf_asg_instance_ssh() {
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME stack [user]"; return 1; fi
   local stack="$(basename $1 .json)"
-  local user=${2:-$(id --user --name)}
+  local user=${2:-$(echo $USER)}
   local instance_ip="$(cf_asg_instances $stack | head -1 | cut -f 1)"
   ssh ${user}@${instance_ip}
 }

--- a/cloudformation-functions
+++ b/cloudformation-functions
@@ -241,7 +241,7 @@ cf_asg_instances() {
 cf_asg_instance_ssh() {
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME stack [user]"; return 1; fi
   local stack="$(basename $1 .json)"
-  local user=${2:-root}
+  local user=${2:-$(id --user --name)}
   local instance_ip="$(cf_asg_instances $stack | head -1 | cut -f 1)"
   ssh ${user}@${instance_ip}
 }


### PR DESCRIPTION
The default user should be the effective user id, rather than root, for the `cf_asg_instance_ssh` function.  Although there is no right and wrong choice for the default user, it makes more sense to have the effective user as the default user.