### PR TITLE
cf_rm_inactive_volumes() function would remove all the volumes which …

### DIFF
--- a/cloudformation-functions
+++ b/cloudformation-functions
@@ -372,4 +372,18 @@ cf_elbs() {
   fi
 }
 
+cf_rm_inactive_volumes() {
+  ids=$(aws ec2 describe-volumes --output=text --query 'Volumes[?State!=`in-use`].VolumeId')
+  arr=()
+  read -a arr <<< "$ids"
+  if((${#arr[@]}==0)); then
+    echo "all volumes is in-use, no volume could be deleted"
+  else
+    for id in "${arr[@]}"; do
+      aws ec2 delete-volume --volume-id "$id"
+      echo "volume $id is deleted"
+    done
+  fi
+}
+
 


### PR DESCRIPTION
…is not in-use, the detail is here : https://github.com/realestate-com-au/bash-my-aws/issues/9.

Also I noticed, in the `instances-functions` script, you already have a function `instance_volumes()` which could query all the volumes against instance id, so I think my proposal 1:
> 1. Add a function to list all volumes, and could also sort volumes by category.

might not be that useful any more. so I decide just add the function of remove all in-active volumes. 