### PR TITLE
Make (most) functions pipeable. Thanks @jonhiggs

### DIFF
--- a/bma_read_inputs-example.sh
+++ b/bma_read_inputs-example.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# # set -u
+
+bma_read_inputs() {
+  echo "${FUNCNAME}: \$@='${@}'" >&2
+  if [[ -t 0 ]]; then
+    echo "${FUNCNAME}: STDIN is a terminal" >&2
+    echo $@
+  else
+    echo "${FUNCNAME}: STDIN is not a terminal" >&2
+    local args="$@"
+    echo "$(awk '{ print $1 }')" | 
+      sed "s/.$/& /"             | 
+      sed "s/$/$args/"
+  fi
+}
+
+foo(){
+  echo "${FUNCNAME}: \$@='${@}'" >&2
+  local inputs="$(bma_read_inputs $@)"
+  echo "${FUNCNAME}: inputs=${inputs}" >&2
+  bar $@
+}
+
+bar(){
+  echo "${FUNCNAME}: \$@='${@}'" >&2
+  local inputs="$(bma_read_inputs $@)"
+  echo "${FUNCNAME}: inputs=${inputs}" >&2
+}

--- a/bma_read_inputs-example.sh
+++ b/bma_read_inputs-example.sh
@@ -9,8 +9,8 @@ bma_read_inputs() {
   else
     echo "${FUNCNAME}: STDIN is not a terminal" >&2
     local args="$@"
-    echo "$(awk '{ print $1 }')" | 
-      sed "s/.$/& /"             | 
+    echo "$(awk '{ print $1 }')" |
+      sed "s/.$/& /"             |
       sed "s/$/$args/"
   fi
 }

--- a/instance-functions
+++ b/instance-functions
@@ -1,56 +1,94 @@
 #!/bin/bash
 
-# instance-functions.sh
+# instance-functions
 #
 # List, run, start, stop and ssh to Amazon AWS EC2 instances
 
-# Fields to include when listing EC2 Instances
-INSTANCE_OUTPUT="[InstanceId, State.Name, InstanceType, PrivateIpAddress, PublicIpAddress, join(\` \`, [Tags[?Key==\`Name\`].Value][]), join(\` \`, [Tags[?Key==\`contact\`].Value][]), LaunchTime]"
-
-#  Fields to include when listing EBS volumes
-VOLUME_OUTPUT='[VolumeId, Size, VolumeType, State, CreateTime]'
+source $(dirname ${BASH_SOURCE[0]})/shared-functions
 
 instances() {
-  aws ec2 describe-instances $filters --query "Reservations[].Instances[].${INSTANCE_OUTPUT}" --output text | grep "$1"
+  # query
+  instance_ids=$(__bma_read_inputs $@)
+  [[ -z $instance_ids ]] || instance_ids="--instance-ids ${instance_ids}"
+
+  if [[ ! -z ${INSTANCE_FILTERS} ]]; then
+    filters="--filters ${INSTANCE_FILTERS}"
+  else
+    filters=""
+  fi
+
+  aws ec2 describe-instances $filters $instance_ids \
+    --query "Reservations[].Instances[].${INSTANCE_OUTPUT}" \
+    --output ${BMA_OUTPUT}
 }
 
-instances_with_tag() {
+instances_tagged() {
+  # query
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME tag_key [tag_value]"; return 1; fi
   local tag_name=$1
-  local tag_value=$2
-  if [ -z "$tag_value" ]; then
-    aws ec2 describe-instances --output text --query "Reservations[].Instances[?contains(Tags[].Key[], \`$tag_name\`) == \`true\`][].${INSTANCE_OUTPUT}"
-  else
-    aws ec2 describe-instances --output text --query "Reservations[].Instances[?contains(Tags[?Key==\`$tag_key\`].Value[], \`$tag_value\`) == \`true\`][].${INSTANCE_OUTPUT}"
-  fi
+  local tag_value=${2:-"*"}
+  INSTANCE_FILTERS="Name=tag:${tag_name},Values=${tag_value}" instances
 }
 
+# legacy - doesn't fit new pipeable architecture
 instances_without_tag() {
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME tag_key [tag_value]"; return 1; fi
   local tag_key=$1
   local tag_value=$2
   if [ -z "$tag_value" ]; then
-    aws ec2 describe-instances --output text --query "Reservations[].Instances[?contains(Tags[].Key[], \`$tag_key\`) != \`true\`][].${INSTANCE_OUTPUT}"
+    aws ec2 describe-instances                                                                                   \
+      --query "Reservations[].Instances[?contains(Tags[].Key[], \`$tag_key\`) != \`true\`][].${INSTANCE_OUTPUT}" \
+      --output text
   else
-    aws ec2 describe-instances --output text --query "Reservations[].Instances[?contains(Tags[?Key==\`$tag_key\`].Value[], \`$tag_value\`) != \`true\`][].${INSTANCE_OUTPUT}"
+    aws ec2 describe-instances \
+      --query "Reservations[].Instances[?contains(Tags[?Key==\`$tag_key\`].Value[], \`$tag_value\`) != \`true\`][].${INSTANCE_OUTPUT}" \
+      --output text
   fi
 }
 
+instance_asg() {
+  # detail
+  INSTANCE_OUTPUT="[ InstanceId Tags ]" \
+    instances $(__bma_read_inputs $@)       |
+    grep -E -e "i-[0-9a-f]{8}" -e "aws:autoscaling:groupName"  |
+    sed -E 's/aws:autoscaling:groupName//g' |
+    sed -E 's/(i-[0-9a-f]{8})/\1:/'     |
+    sed -E 's/([^\:])$/\1;/g'           |
+    tr -d '\n'                          |
+    tr ':' ' '                          |
+    tr ';' '\n'
+}
 
 instance_console_output() {
-  if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance_id"; return 1; fi 
-  local instance_id=$1
-  aws ec2 get-console-output --instance-id $instance_id --query Output --output text
+  # detail
+  for instance_id in $(__bma_read_inputs $@); do
+    aws ec2 get-console-output    \
+      --instance-id $instance_id  \
+      --query Output              \
+      --output text
+  done
+}
+
+instance_iam_profile() {
+  # detail
+  instance_ids=$(__bma_read_inputs $@)
+  INSTANCE_OUTPUT="[ InstanceId IamInstanceProfile.Id ]" \
+    instances $instance_ids
 }
 
 instance_role() {
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance_id"; return 1; fi
   local instance_id=$1
-  local iam_instance_profile_id=$(aws ec2 describe-instances --instance-id $instance_id --query "Reservations[].Instances[].IamInstanceProfile.Id" --output text)
-  aws iam list-instance-profiles --query "InstanceProfiles[?InstanceProfileId==\`$iam_instance_profile_id\`].Roles[].RoleName" --output text
+  local profile_id=$(aws ec2 describe-instances --instance-id $instance_id \
+    --query "Reservations[].Instances[].IamInstanceProfile.Id"             \
+    --output text)
+  aws iam list-instance-profiles                                                     \
+    --query "InstanceProfiles[?InstanceProfileId==\`$profile_id\`].Roles[].RoleName" \
+    --output text
 }
 
 instance_ssh() {
+
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance-id [user]"; return 1; fi
   local instance_id=$1
   local user=$2
@@ -85,6 +123,17 @@ instance_ssh_details() {
     ]" --output text
 }
 
+instance_stack() {
+  # detail. returns a stack resource.
+  INSTANCE_OUTPUT="[ InstanceId Tags ]"       \
+    instances $(__bma_read_inputs $@)             |
+    grep -E -e "aws:cloudformation:stack-id"  |
+    cut -d: -f8                               |
+    cut -d/ -f2                               |
+    sort                                      |
+    uniq
+}
+
 instance_start() {
   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance-id"; return 1; fi
   aws ec2 start-instances --instance-id $1
@@ -100,23 +149,53 @@ instance_terminate() {
   aws ec2 terminate-instances --instance-id $1
 }
 
+instance_type() {
+  # detail. returns an instance_type resource.
+  INSTANCE_OUTPUT="[ InstanceId InstanceType ]" \
+    instances $(__bma_read_inputs $@) |
+    awk '{ print $2 }' |
+    sort |
+    uniq
+}
+
 instance_types() {
-  aws ec2 describe-instances --filters Name=instance-state-name,Values=running --query "Reservations[].Instances[].[InstanceType]" --output text | sort | uniq -c
+  # query + detail
+  INSTANCE_OUTPUT="[ InstanceId InstanceType ]" \
+    instances $(__bma_read_inputs $@)               |
+      awk '{ print $2 }'                        |
+      sort | uniq -c
 }
 
 instance_userdata() {
-  if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance-id"; return 1; fi
-  local instance_id=$1
-  aws ec2 describe-instance-attribute --attribute userData --instance-id $instance_id --query UserData --output text | base64 --decode
+  # detail
+  for instance_id in $(__bma_read_inputs $@); do
+    aws ec2 describe-instance-attribute         \
+      --attribute userData                      \
+      --instance-id $instance_id                \
+      --query UserData                          \
+      --output text                             |
+        base64 --decode
+  done
 }
 
 instance_volumes() {
-  if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance_id [instance_id]"; return 1; fi
-  local instance_ids=$@
-  if local volume_ids=$(aws ec2 describe-instances --instance-ids $instance_ids --query "Reservations[].Instances[].BlockDeviceMappings[].Ebs[].VolumeId" --output text)
-  then
-    aws ec2 describe-volumes --volume-ids $volume_ids --query "Volumes[].$VOLUME_OUTPUT" --output text
-  else
-    >&2 echo "No volumes found"
-  fi
+  # detail
+  # TODO: fix the output.
+  INSTANCE_OUTPUT="BlockDeviceMappings[].Ebs[].VolumeId" \
+    instances $(__read_inputs $@)
 }
+
+# instance_volumes() {
+#   if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance_id [instance_id]"; return 1; fi
+#   local instance_ids=$@
+#   if local volume_ids=$(aws ec2 describe-instances --instance-ids $instance_ids \
+#    --query "Reservations[].Instances[].BlockDeviceMappings[].Ebs[].VolumeId"    \
+#    --output text)
+#   then
+#     aws ec2 describe-volumes --volume-ids $volume_ids \
+#       --query "Volumes[].$VOLUME_OUTPUT"              \
+#       --output text
+#   else
+#     >&2 echo "No volumes found"
+#   fi
+# }

--- a/instance-functions
+++ b/instance-functions
@@ -180,7 +180,7 @@ instance_volumes() {
   # detail
   # TODO: fix the output.
   INSTANCE_OUTPUT="BlockDeviceMappings[].Ebs[].VolumeId" \
-    instances $(__read_inputs $@)
+    instances $(__bma_read_inputs $@)
 }
 
 # instance_volumes() {

--- a/instance-functions
+++ b/instance-functions
@@ -8,18 +8,18 @@ source $(dirname ${BASH_SOURCE[0]})/shared-functions
 
 instances() {
   # query
-  instance_ids=$(__bma_read_inputs $@)
-  [[ -z $instance_ids ]] || instance_ids="--instance-ids ${instance_ids}"
+  local instance_ids=$(__bma_read_inputs $@)
+  [[ -z $instance_ids ]] || local instance_ids="--instance-ids ${instance_ids}"
 
   if [[ ! -z ${INSTANCE_FILTERS} ]]; then
-    filters="--filters ${INSTANCE_FILTERS}"
+    local filters="--filters ${INSTANCE_FILTERS}"
   else
-    filters=""
+    local filters=""
   fi
 
   aws ec2 describe-instances $filters $instance_ids \
     --query "Reservations[].Instances[].${INSTANCE_OUTPUT}" \
-    --output ${BMA_OUTPUT}
+    --output text
 }
 
 instances_tagged() {
@@ -89,44 +89,43 @@ instance_role() {
 
 instance_ssh() {
 
-  if [ -z "$1" ] ; then echo "Usage: $FUNCNAME instance-id [user]"; return 1; fi
-  local instance_id=$1
-  local user=$2
-
-  local instance_details=$(instance_ssh_details $instance_id)
-  local keyname=$(echo "$instance_details" | awk '{print $1}');
-  local ip=$(echo "$instance_details" | awk '{print $2}');
-  local instance_name=$(echo "$instance_details" | awk '{print $3}');
-  local instance_default_user=$(echo "$instance_details" | awk '{print $4}');
+  IFS=' ' read instance_id user trash <<< $(__bma_read_inputs $@ | head -1)
+  if [ -z "$instance_id" ] ; then echo "Usage: $FUNCNAME instance-id [user]"; return 1; fi
+  local instance_details="$(instance_ssh_details $instance_id)"
+  local keyname=$(echo $instance_details | awk '{print $1}');
+  local ip=$(echo $instance_details | awk '{print $2}');
+  local instance_name=$(echo $instance_details | awk '{print $3}');
+  local instance_default_user=$(echo $instance_details | awk '{print $4}');
 
   local USERNAME=${user:-${instance_default_user:-${AWS_DEFAULT_USER:-root}}}
   echo "Connecting to $instance_id $instance_name"
-  ssh \
-    -t \
-    -i ~/.ssh/$keyname \
-    -o LogLevel=quiet \
-    -o StrictHostKeyChecking=no \
+  ssh                               \
+    $debug_arg                      \
+    -t                              \
+    -i ~/.ssh/$keyname              \
+    -o LogLevel=error               \
+    -o StrictHostKeyChecking=no     \
     -o UserKnownHostsFile=/dev/null \
-    -l $USERNAME \
+    -l $USERNAME                    \
     $ip
 }
 
 instance_ssh_details() {
-  if [ -z "$1" ] ; then echo "Usage: $FUNCNAME stack [template]"; return 1; fi
-  local instance_id=$1
-  aws ec2 describe-instances --filters Name=instance-id,Values=$instance_id --query "
-    Reservations[].Instances[0].[
+  local instance_id="$(__bma_read_inputs $@)"
+  if [ -z "$instance_id" ] ; then echo "Usage: $FUNCNAME instance_id"; return 1; fi
+  INSTANCE_FILTERS="Name=instance-id,Values=${instance_id}"           \
+  INSTANCE_OUTPUT="[ 
       KeyName,
       PrivateIpAddress,
       join(\` \`, [Tags[?Key==\`Name\`].Value][] || [\`not-named\`]),
       join(\` \`, [Tags[?Key==\`default-user\`].Value][] || [\`\`])
-    ]" --output text
+  ]" instances
 }
 
 instance_stack() {
   # detail. returns a stack resource.
   INSTANCE_OUTPUT="[ InstanceId Tags ]"       \
-    instances $(__bma_read_inputs $@)             |
+    instances $(__bma_read_inputs $@)         |
     grep -E -e "aws:cloudformation:stack-id"  |
     cut -d: -f8                               |
     cut -d/ -f2                               |

--- a/instance-functions
+++ b/instance-functions
@@ -88,7 +88,6 @@ instance_role() {
 }
 
 instance_ssh() {
-
   IFS=' ' read instance_id user trash <<< $(__bma_read_inputs $@ | head -1)
   if [ -z "$instance_id" ] ; then echo "Usage: $FUNCNAME instance-id [user]"; return 1; fi
   local instance_details="$(instance_ssh_details $instance_id)"
@@ -99,9 +98,9 @@ instance_ssh() {
 
   local USERNAME=${user:-${instance_default_user:-${AWS_DEFAULT_USER:-root}}}
   echo "Connecting to $instance_id $instance_name"
+  
   ssh                               \
-    $debug_arg                      \
-    -t                              \
+    -tt                             \
     -i ~/.ssh/$keyname              \
     -o LogLevel=error               \
     -o StrictHostKeyChecking=no     \

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,24 @@
+## dev guidelines
+
+star fork
+ 545   52   pact
+  46   19   bash-my-aws
+  43   12   credulous
+
+* alphabetise
+
+? won't BMA_OUTPUT break some things if not text?
+? what do we do about piping to ssh (user arg) - can we use both?
+
+what happens when we pipe nothing through?
+- instances | grep foobar | instance_types
+
+instances_tagged()
+- kept original names (instance_with_tag) for backward compatibility
+- happy to consider breaking change
+
+instance_volumes()
+- left it out for now till we sort out output
+
+instance_types()
+- query+detail? or just detail?

--- a/notes.md
+++ b/notes.md
@@ -5,10 +5,17 @@ star fork
   46   19   bash-my-aws
   43   12   credulous
 
+
+TODO
+instance_stack() use --query
+instance_type()  use --query
+instance_types() use --query # remove
+
 * alphabetise
 
-? won't BMA_OUTPUT break some things if not text?
 ? what do we do about piping to ssh (user arg) - can we use both?
+
+BMA_OUTPUT remove?
 
 what happens when we pipe nothing through?
 - instances | grep foobar | instance_types
@@ -20,5 +27,13 @@ instances_tagged()
 instance_volumes()
 - left it out for now till we sort out output
 
-instance_types()
-- query+detail? or just detail?
+
+Test
+1. terminal
+1. no terminal
+1. arguments
+1. no arguments
+1. STDIN single line, single field 
+1. STDIN single line, multiple fields
+1. STDIN mutiple lines, single field
+1. STDIN mutiple lines, multiple fields

--- a/shared-functions
+++ b/shared-functions
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ -z ${BMA_OUTPUT} ]]; then
   BMA_OUTPUT="text"
 fi
@@ -38,10 +40,25 @@ if [[ -z ${ASG_OUTPUT} ]]; then
 fi
 
 __bma_read_inputs() {
-  if [[ -t 0 ]] || [[ -n $1 ]]; then
+  if [[ -t 0 ]]; then
     echo $@
   else
-    awk '{ print $1 }' </dev/stdin
+    local args="$@"
+    awk '{ print $1 }' | sed "s/.$/& /" | sed "s/$/$args/"
+  fi
+}
+
+__bma_read_inputs() {
+  echo "${FUNCNAME}: \$@='${@}'" >&2
+  if [[ -t 0 ]]; then
+    echo "${FUNCNAME}: STDIN is a terminal" >&2
+    echo $@
+  else
+    echo "${FUNCNAME}: STDIN is not a terminal" >&2
+    local args="$@"
+    echo "$(awk '{ print $1 }')" |
+      sed "s/.$/& /"             |
+      sed "s/$/$args/"
   fi
 }
 

--- a/shared-functions
+++ b/shared-functions
@@ -1,0 +1,48 @@
+if [[ -z ${BMA_OUTPUT} ]]; then
+  BMA_OUTPUT="text"
+fi
+
+if [[ -z ${INSTANCE_OUTPUT} ]]; then
+  INSTANCE_OUTPUT="[
+    InstanceId,
+    State.Name,
+    InstanceType,
+    PrivateIpAddress,
+    PublicIpAddress,
+    join(\` \`, [Tags[?Key==\`Name\`].Value][]),
+    join(\` \`, [Tags[?Key==\`contact\`].Value][]),
+    LaunchTime
+  ]"
+fi
+
+if [[ -z ${VOLUME_OUTPUT} ]]; then
+  VOLUME_OUTPUT='[VolumeId, Size, VolumeType, State, CreateTime]'
+fi
+
+if [[ -z ${INSTANCE_OUTPUT} ]]; then
+  INSTANCE_PROFILE_OUTPUT="[
+    Profile
+  ]"
+fi
+
+if [[ -z ${ELB_OUTPUT} ]]; then
+  ELB_OUTPUT="[
+    LoadBalancerName
+  ]"
+fi
+
+if [[ -z ${ASG_OUTPUT} ]]; then
+  ASG_OUTPUT="[
+    AutoScalingGroupName
+  ]"
+fi
+
+__bma_read_inputs() {
+  if [[ -t 0 ]] || [[ -n $1 ]]; then
+    echo $@
+  else
+    awk '{ print $1 }' </dev/stdin
+  fi
+}
+
+# vim: ft=sh

--- a/shared-functions
+++ b/shared-functions
@@ -40,21 +40,12 @@ if [[ -z ${ASG_OUTPUT} ]]; then
 fi
 
 __bma_read_inputs() {
+  # echo "${FUNCNAME}: \$@='${@}'" >&2
   if [[ -t 0 ]]; then
+    # echo "${FUNCNAME}: STDIN is a terminal" >&2
     echo $@
   else
-    local args="$@"
-    awk '{ print $1 }' | sed "s/.$/& /" | sed "s/$/$args/"
-  fi
-}
-
-__bma_read_inputs() {
-  echo "${FUNCNAME}: \$@='${@}'" >&2
-  if [[ -t 0 ]]; then
-    echo "${FUNCNAME}: STDIN is a terminal" >&2
-    echo $@
-  else
-    echo "${FUNCNAME}: STDIN is not a terminal" >&2
+    # echo "${FUNCNAME}: STDIN is not a terminal" >&2
     local args="$@"
     echo "$(awk '{ print $1 }')" |
       sed "s/.$/& /"             |


### PR DESCRIPTION
Copied in changes from @jonhiggs
https://github.com/jonhiggs/bash-my-aws/blob/cleanup/instance-functions

__bma_read_inputs() will gather input from arguments or STDIN

This allows us to pipe output from one command into another.

e.g.
```
$ instances | grep docker |instance_types
   4 m3.medium
```