### PR TITLE
Reviewed the test framework and optimised it:

### DIFF
--- a/test/bash-spec.sh
+++ b/test/bash-spec.sh
@@ -14,67 +14,59 @@
 # Modified by REA Group 2014
 #==================================================================================
 
-result_file=$RANDOM
+# XXX: should use mktemp for proper random file name -- (GM)
+result_file="$RANDOM"
+_passed_=0
+_failed_=0
 
 exec 6<&1
 exec > "$result_file"
 
 function output_results {
   exec 1>&6 6>&-
-  local results=$( cat "$result_file" )
-  rm "$result_file"
-  local passes=$( echo "$results" | grep "PASS" | wc -l )
-  local fails=$( echo "$results" | grep "\*\*\*\* FAIL" | wc -l )
-  echo "$results"
-  echo "--SUMMARY--"
-  echo "$passes PASSED"
-  echo "$fails FAILED"
-  if [[ $fails -gt 0 ]]; then
-    exit 1
-  else
-    exit 0
-  fi
+  local results="$(<$result_file)"
+  rm -f -- "$result_file"
+  local passes=$(printf '%s' "$results" | grep -F PASS | wc -l)
+  local fails=$(printf '%s' "$results" | grep -F '**** FAIL' | wc -l )
+  printf '%s\n--SUMMARY\n%d PASSED\n%d FAILED\n' "$results" "$passes" "$fails"
+  [[ ${fails:-1} -gt 0 ]]
+  exit $?
 }
 
 function _array_contains_ {
   for elem in "${_actual_[@]}"; do
-      if [[ "$elem" == "$_expected_" ]]; then
-          return 0
-      fi
+    [[ "$elem" == "$_expected_" ]] && return 0
   done
   return 1
 }
 
 function _negation_check_ {
-    if [[ "$_negation_" == true ]]; then
-        if [[ "$_pass_" == true ]]; then
-            _pass_=false
-        else
-            _pass_=true
-        fi      
-    fi  
+  if [[ "$_negation_" == true ]]; then
     if [[ "$_pass_" == true ]]; then
-        (( _passed_+=1 ))
-        pass
+      _pass_=false
     else
-        (( _failed_+=1 ))
-        fail
+      _pass_=true
     fi
+  fi
+  if [[ "$_pass_" == true ]]; then
+    (( _passed_+=1 ))
+    pass
+  else
+    (( _failed_+=1 ))
+    fail
+  fi
 }
 
 function it {
-  echo "  $1"
-  echo "    $2"
+  printf '  %s\n    %s\n' "$1" "$2"
 }
 
 function describe {
-  echo "$1"
-  echo "$2"
+  printf '%s\n%s\n' "$1" "$2"
 }
 
 function context {
-  echo "$1"
-  echo "$2"
+  printf '%s\n%s\n' "$1" "$2"
 }
 
 function pass {
@@ -82,17 +74,17 @@ function pass {
 }
 
 function fail {
-  echo "**** FAIL - expected:$( if [[ "$_negation_" == true ]]; then echo " NOT"; fi; ) '$_expected_' | actual: '${_actual_[@]}'"
+  echo "**** FAIL - expected:$( if [[ '$_negation_' == true ]]; then echo ' NOT'; fi; ) '$_expected_' | actual: '${_actual_[@]}'"
 }
 
 function expect {
   _expected_=
-    _negation_=false
-    declare -a _actual_
-    until [[ "$1" == to_* || "$1" == not || -z "$1" ]]; do
-        _actual_+=("$1")
-        shift
-    done
+  _negation_=false
+  declare -a _actual_
+  until [[ "${1:0:3}" == to_ || "$1" == not || -z "$1" ]]; do
+    _actual_+=("$1")
+    shift
+  done
   "$@"
 }
 
@@ -102,90 +94,73 @@ function not {
 }
 
 function to_be {
-    _expected_="$1"
-    if [[ "${_actual_[0]}" == "$_expected_" ]]; then 
-        _pass_=true
-    else
-        _pass_=false
-    fi
-    _negation_check_
+  _expected_="$1"
+  _pass_=false
+  [[ "${_actual_[0]}" == "$_expected_" ]] && _pass_=true
+  _negation_check_
 }
 
 function to_be_true {
   _expected_="$@ IS TRUE"
-  if $@; then
+  _pass=false
+  _actual_="$@ IS FALSE"
+  if "$@"; then
     _pass_=true
     _actual_="$@ IS TRUE"
-  else
-    _pass=false
-    _actual_="$@ IS FALSE"
   fi
   _negation_check_
 }
 
 function to_match {
-    _expected_="$1"
-    if [[ "${_actual_[0]}" =~ $_expected_ ]]; then 
-        _pass_=true
-    else
-        _pass_=false
-    fi
-    _negation_check_
+  _expected_="$1"
+  _pass_=false
+  [[ "${_actual_[0]}" =~ "$_expected_" ]] && _pass_=true
+  _negation_check_
 }
 
 function to_contain {
-    _expected_="$1"
-    
-    if _array_contains_ "$_expected_" "$_actual_"; then 
-        _pass_=true
-    else
-        _pass_=false
-    fi
-    _negation_check_
+  _expected_="$1"
+  _pass_=false
+  _array_contains_ "$_expected_" "$_actual_" && _pass_=true
+  _negation_check_
 }
 
 function to_exist {
+  _pass_=false
+  _expected_="$_actual_ EXISTS"
+  _actual_="File not found"
   if [[ -e "${_actual_[0]}" ]]; then
-        _pass_=true
-        if [[ "$_negation_" == true ]]; then
-          _expected_="$_actual_ EXISTS"
-        fi
+    _pass_=true
+    [[ "$_negation_" == true ]] && _expected_="$_actual_ EXISTS"
+  fi
+  _negation_check_
+}
+
+function to_have_mode {
+  _filename_="${_actual_[0]}"
+  _expected_="$1"
+  _pass_=false
+  if [[ -e "$_filename_" ]]; then
+    _fullname_="$_filename_"
+  else
+    _fullname_="$(which $_filename_)"
+  fi
+  if [[ -e "$_fullname_" ]]; then
+    _os_="$(uname -s)"
+    if [[ "$_os_" == Linux ]]; then
+      _actual_="$(stat -c %A $_fullname_)"
     else
-        _pass_=false
-        _expected_="$_actual_ EXISTS"
-        _actual_="File not found"
+      _actual_="$(stat $_fullname_ | cut -f 3 -d ' ')"
     fi
-    _negation_check_
+    [[ "$_actual_" =~ "$_expected_" ]] && _pass_=true
+  else
+    echo "File not found: $_fullname_"
+  fi
+  _negation_check_
 }
 
-function to_have_mode { 
-    _filename_="${_actual_[0]}"
-    _expected_="$1"
-    if [[ -e "$_filename_" ]]; then
-      _fullname_="$_filename_"
-    else
-      _fullname_="$(which $_filename_)"
-    fi  
-    if [[ -e "$_fullname_" ]]; then
-      _os_=$(uname -a | cut -f 1 -d ' ')
-      if [[ $_os_ == Linux ]]; then
-        _actual_="$(stat -c %A $_fullname_)"
-      else
-        _actual_="$(stat $_fullname_ | cut -f 3 -d ' ')"
-      fi
-      if [[ "$_actual_" =~ $_expected_ ]]; then
-        _pass_=true
-      else
-        _pass_=false
-      fi
-      _negation_check_
-    else
-      echo "File not found: $_fullname_"
-    fi        
-}
-
-TEMP=`getopt -o h --long help \
-             -n 'javawrap' -- "$@"`
+TEMP="$(getopt -o h --long help \
+             -n 'javawrap' -- $@)"
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 

--- a/test/bash-spec.sh
+++ b/test/bash-spec.sh
@@ -29,7 +29,7 @@ function output_results {
   local passes=$(printf '%s' "$results" | grep -F PASS | wc -l)
   local fails=$(printf '%s' "$results" | grep -F '**** FAIL' | wc -l )
   printf '%s\n--SUMMARY\n%d PASSED\n%d FAILED\n' "$results" "$passes" "$fails"
-  [[ ${fails:-1} -gt 0 ]]
+  [[ ${fails:-1} -eq 0 ]]
   exit $?
 }
 


### PR DESCRIPTION
- put a comment suggesting to use mktemp for temporary file names;
- reformatted the script to consistently follow the indentation;
- ensured that the variables are used consistently (no curly brackets unless they are truly required, double quotes around the variables, etc.)
- in the output() function ensured that if the $fails counter is not defined it would be also considered a failure;
- replaced multiple calls to echo with a single call to printf for performance;
- optimised some conditional logic to be fail-safe, e.g. set the failure state first, then conditionally update it if the test succeeds;
- in the to_have_mode() function relocated the negation check to the end of the routine, so it would be possible to do a negation check (I left the message re: 'file not found' intact).