### PR TITLE
Instances with id fix

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -68,6 +68,7 @@ complete -F _bma_asgs_completion asg-instances
 complete -F _bma_asgs_completion asg-processes_suspended
 complete -F _bma_asgs_completion asg-resume
 complete -F _bma_asgs_completion asg-suspend
+complete -F _bma_asgs_completion asg-scaling-activities
 complete -F _bma_stacks_completion stacks
 complete -F _bma_stacks_completion stack-cancel-update
 complete -F _bma_stacks_completion stack-update

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -1,3 +1,11 @@
+_bma_elbs_completion() {
+    local command="$1"
+    local word="$2"
+    local options=$(elbs)
+    COMPREPLY=($(compgen -W "${options}" -- ${word}))
+    return 0
+}
+
 _bma_stacks_completion() {
   local command="$1"
   local word="$2"
@@ -77,4 +85,5 @@ complete -F _bma_stacks_completion stack-tail
 complete -F _bma_stacks_completion stack-template
 complete -F _bma_stacks_completion stack-outputs
 complete -F _bma_stacks_completion stack-diff
+complete -F _bma_elbs_completion elb-instances
 complete -f stack-validate

--- a/lib/asg-functions
+++ b/lib/asg-functions
@@ -169,4 +169,17 @@ asg-suspend() {
   done
 }
 
+asg-scaling-activities() {
+  # type: query
+  # show all scaling activities
+  local inputs=$(__bma_read_inputs $@)
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  [[ -z "$inputs" ]] && __bma_usage "auto-scaling-group" && return 1
+  for asg in $(__bma_read_resources ${inputs}); do
+    aws autoscaling describe-scaling-activities \
+      --auto-scaling-group-name $asg            \
+      --output ${output:-json}
+  done
+}
+
 # vim: ft=sh

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -5,7 +5,8 @@
 elbs() {
   # type: query
   # returns a list of ELBS
-  local inputs=$(__bma_read_inputs $@)
+  # FIXME: support regex against the inputs
+  [[ $# -ne 0 ]] && __bma_usage "" && return 1
 
   local default_query='
     LoadBalancerDescriptions[][

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -35,8 +35,8 @@ elb-instances() {
   # returns launch configuration of an elb
 
   # FIXME: doesn't support multiple ELB names
-  [[ $# -ne 1 ]] && __bma_usage "load-balancer" && return 1
   local inputs=$(__bma_read_inputs $@)
+  [[ -z "${inputs}" ]] && __bma_usage "load-balancer" && return 1
 
   local default_query='
     InstanceStates[][

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -29,3 +29,35 @@ elbs() {
     --query "${query}"                                            \
     --output ${output:-"text"}
 }
+
+elb-instances() {
+  # type: detail
+  # returns launch configuration of an elb
+
+  # FIXME: doesn't support multiple ELB names
+  [[ $# -ne 1 ]] && __bma_usage "load-balancer" && return 1
+  local inputs=$(__bma_read_inputs $@)
+
+  local default_query='
+    InstanceStates[][
+      [
+        InstanceId,
+        State,
+        ReasonCode
+      ]
+    ][]
+  '
+
+  local elb_name=$(__bma_read_resources $inputs)
+  local filters=$(__bma_read_switches $inputs | grep ^--filters | cut -d\  -f2-)
+  local query=$(__bma_read_switches $inputs | grep ^--query | cut -d\  -f2-)
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  [[ -z $query ]] && query=$default_query
+
+  aws elb describe-instance-health                                   \
+    $([[ -n ${elb_name} ]] && echo --load-balancer-name ${elb_name}) \
+    $([[ -n ${filters} ]] && echo "--filters ${filters}")            \
+    --query "${query}"                                               \
+    --output ${output:-"text"}
+}
+

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# elb-functions
+
+elbs() {
+  # type: query
+  # returns a list of ELBS
+  local inputs=$(__bma_read_inputs $@)
+
+  local default_query='
+    LoadBalancerDescriptions[][
+      {
+        "Name": LoadBalancerName
+      }
+    ][]
+  '
+
+  local elb_names=$(__bma_read_resources $inputs)
+  local filters=$(__bma_read_switches $inputs | grep ^--filters | cut -d\  -f2-)
+  local query=$(__bma_read_switches $inputs | grep ^--query | cut -d\  -f2-)
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  [[ -z $query ]] && query=$default_query
+
+  aws elb describe-load-balancers                                 \
+    $([[ -n ${elb_names} ]] && echo --load-balancer-names)        \
+    $(for x in ${elb_names}; do echo $x; done)                    \
+    $([[ -n ${filters} ]] && echo "--filters ${filters}")         \
+    --query "${query}"                                            \
+    --output ${output:-"text"}
+}

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -44,7 +44,7 @@ instances() {
   [[ -z $query ]] && local query=$default_query
 
   aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+    $([[ -n ${instance_ids} ]] && echo --instance-ids) ${instance_ids}  \
     $([[ -n ${filters} ]] && echo "--filters ${filters}")               \
     --query "${query}"                                                  \
     --output ${output:-"text"}

--- a/test/generate_bash_completion
+++ b/test/generate_bash_completion
@@ -2,6 +2,14 @@
 ROOT_DIR="$(dirname $0)/../"
 
 cat <<EOF
+_bma_elbs_completion() {
+    local command="\$1"
+    local word="\$2"
+    local options=\$(elbs)
+    COMPREPLY=(\$(compgen -W "\${options}" -- \${word}))
+    return 0
+}
+
 _bma_stacks_completion() {
   local command="\$1"
   local word="\$2"
@@ -41,7 +49,7 @@ _bma_asgs_completion() {
 
 EOF
 
-for type in instance asg stack; do
+for type in instance asg stack elb; do
   functions=$(
     cat ${ROOT_DIR}/lib/${type}-functions |
     grep -e "^[^_#][^\ ]*()\ \?{" |
@@ -54,6 +62,7 @@ for type in instance asg stack; do
     [[ "${function}" == "asg-desired-size-set" ]] && continue
     [[ "${function}" == "asg-min-size-set" ]] && continue
     [[ "${function}" == "asg-max-size-set" ]] && continue
+    [[ "${function}" == "elbs" ]] && continue
     echo "complete -F _bma_${type}s_completion ${function}"
   done
 done


### PR DESCRIPTION
Before it was running:

```ShellCommand
++ aws ec2 describe-instances '--instance-ids i-f7313129' --query '
    Reservations[].Instances[][
        InstanceId,
        ImageId,
        InstanceType,
        State.Name,
        [Tags[?Key==`Name`].Value][0][0],
        LaunchTime
    ]
  ' --output text
```

Now it is running:

```ShellCommand
++ aws ec2 describe-instances --instance-ids i-f7313129 --query '
    Reservations[].Instances[][
        InstanceId,
        ImageId,
        InstanceType,
        State.Name,
        [Tags[?Key==`Name`].Value][0][0],
        LaunchTime
    ]
  ' --output text
```