### PR TITLE
Support for EMR clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ $ asg
 asg-capacity             asg-max-size-set         asg-resume               asgs
 asg-desired-size-set     asg-min-size-set         asg-suspend
 asg-instances            asg-processes_suspended  asgard
+
+$ cluster
+cluster-instance-groups  cluster-instances        cluster-steps            clusters
 ```
 
 For more info on the query syntax used by AWSCLI, check out http://jmespath.org/tutorial.html

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -43,6 +43,14 @@ _bma_asgs_completion() {
     return 0
 }
 
+_bma_cluster_completion() {
+    local command="$1"
+    local word="$2"
+    local options=$(clusters --query 'Clusters[][{"Id": Id}][]')
+    COMPREPLY=($(compgen -W "${options}" -- ${word}))
+    return 0
+}
+
 complete -F _bma_instances_completion instances
 complete -F _bma_instances_completion instance-asg
 complete -F _bma_instances_completion instance-az
@@ -88,3 +96,7 @@ complete -F _bma_stacks_completion stack-outputs
 complete -F _bma_stacks_completion stack-diff
 complete -F _bma_elbs_completion elb-instances
 complete -f stack-validate
+complete -F _bma_cluster_completion clusters
+complete -F _bma_cluster_completion cluster-instance-groups
+complete -F _bma_cluster_completion cluster-instances
+complete -F _bma_cluster_completion cluster-steps

--- a/lib/cluster-functions
+++ b/lib/cluster-functions
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# emr-functions
+
+source $(dirname ${BASH_SOURCE[0]})/shared.inc
+
+clusters() {
+  # type: query
+
+  local default_query='
+    Clusters[][
+      {
+        "Id": Id,
+        "Name": Name,
+        "State": Status.State
+      }
+    ]
+  '
+
+  local inputs=$(__bma_read_inputs $@)
+  local grep_args=$(__bma_read_resources $inputs)
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  local query=$(__bma_read_switches $inputs | grep ^--query | cut -d\  -f2-)
+  [[ -z $query ]] && query=$default_query
+
+  local state_switches=$(__bma_read_switches $inputs | grep -E '^--(active|terminated|failed)$')
+  local states=$(__bma_read_switches $inputs | grep ^--states | cut -d\  -f2-)
+  [[ -n $states ]] && state_switches+=" --cluster-states $state"
+
+  local grep_filter=""
+  for arg in ${grep_args}; do
+    grep_filter+="-e ${arg}"
+  done
+
+  aws emr list-clusters \
+    --query "${query}" \
+    $state_switches \
+    --output ${output:-"text"} |
+  grep --color=never ${grep_filter:-".*"}
+}
+
+cluster-instances() {
+  # type: query
+
+  local inputs=$(__bma_read_inputs $@)
+  local clusters=$(__bma_read_resources $inputs)
+  [[ -z "$clusters" ]] && __bma_usage "cluster-id" && return 1
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  local query='
+    Instances[][
+      {
+        "InstanceId": Ec2InstanceId,
+        "State": Status.State,
+        "Ip": PrivateIpAddress
+      }
+    ]
+  '
+
+  # Need to come through instance-groups if you want the InstanceGroupType
+  for cluster in $clusters; do
+    aws emr list-instances \
+      --query "${query}" \
+      --cluster-id "$cluster" \
+      --output ${output:-"text"}
+  done
+}
+
+cluster-instance-groups() {
+  # type: query
+
+  local inputs=$(__bma_read_inputs $@)
+  local clusters=$(__bma_read_resources $inputs)
+  [[ -z "$clusters" ]] && __bma_usage "cluster-id" && return 1
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  local query='
+    Cluster.InstanceGroups[][
+      {
+        "Id": Id,
+        "Name": Name,
+        "InstanceGroupType": InstanceGroupType,
+        "InstanceType": InstanceType,
+        "Market": Market,
+        "RequestedInstanceCount": RequestedInstanceCount,
+        "RunningInstanceCount": RunningInstanceCount
+      }
+    ]
+  '
+  for cluster in $clusters; do
+    aws emr describe-cluster \
+      --query "${query}" \
+      --cluster-id "$cluster" \
+      --output ${output:-"text"}
+  done
+}
+
+cluster-steps() {
+  # type: query
+
+  local inputs=$(__bma_read_inputs $@)
+  local clusters=$(__bma_read_resources $inputs)
+  [[ -z "$clusters" ]] && __bma_usage "cluster-id" && return 1
+  local output=$(__bma_read_switches $inputs | grep ^--output | cut -d\  -f2-)
+  local query='
+    Steps[][
+      {
+        "Id": Id,
+        "Name": Name,
+        "State": Status.State,
+        "Command": {
+          "Jar": Config.Jar,
+          "JarArgs": join('"'"' '"'"', Config.Args)
+        }
+      }
+    ]
+  '
+
+  for cluster in $clusters; do
+    aws emr list-steps \
+      --query "$query" \
+      --cluster-id "$cluster" \
+      --output ${output:-"text"}
+  done
+}
+
+# vim: ft=sh

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -43,7 +43,7 @@ instances() {
 
   [[ -z $query ]] && local query=$default_query
 
-  data=$(
+  local data=$(
     aws ec2 describe-instances                                            \
       $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
       $([[ -n ${filters} ]] && echo "--filters ${filters}")               \

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -67,7 +67,7 @@ stacks() {
 
   [[ -z $query ]] && local query='StackSummaries[][ StackName ]'
 
-  grep_filter=""
+  local grep_filter=""
   for arg in ${grep_args}; do
     grep_filter+="-e ${arg} "
   done
@@ -253,7 +253,7 @@ stack-elbs() {
 stack-instances() {
   # type: detail
   # return the instances managed by a stack
-  instance_ids=$(stack-resources $@ | grep AWS::EC2::Instance | cut -f1)
+  local instance_ids=$(stack-resources $@ | grep AWS::EC2::Instance | cut -f1)
   [[ -n "$instance_ids" ]] && instances $instance_ids
 }
 


### PR DESCRIPTION
Proposed working implementation of AWS EMR cluster under cluster\* namespace.

```
$ clusters --active
j-OO7ZS1BEZPI9  My Cluster  BOOTSTRAPPING
$ clusters --active|cluster-instances
i-0c7097a24ea6a37fa 10.4.12.22  BOOTSTRAPPING
i-0fabffcc26f8c63c6 10.4.12.20  BOOTSTRAPPING
i-09b6e5c0ec6fadc8d 10.4.12.196 BOOTSTRAPPING
i-057d4703913ba5b4a 10.4.12.21  BOOTSTRAPPING
$ clusters --active|cluster-instance-groups
ig-1I5II8VJCYU59    MASTER  m4.large    ON_DEMAND   My Master   1   1
ig-277JVX09X5ZZT    CORE    m4.large    ON_DEMAND   My Slaves   3   3
$ sleep 600
$ cluster-steps j-OO7ZS1BEZPI9
s-2HYLCGF2YSFCR Example COMPLETED
COMMAND command-runner.jar  touch /tmp/example
s-3Y7D2ZKUD7YX  Spark Job   COMPLETED
COMMAND command-runner.jar  spark-submit --class org.apache.spark.examples.SparkPi /home/hadoop/spark/lib/spark-examples-*.jar 10
```

Soliciting feedback and/or changes to proposal. Only major design variation is that cluster-steps outputs 2 lines per step (via nested "Command" struct in JMES query). It was done this way to produce sane output that can be filtered with grep.

Pull req hangs off #92 - sorry if this is an issue.
