### PR TITLE
Removed a few commands that appear redundant - am I missing something?

### DIFF
--- a/lib/parameter.inc
+++ b/lib/parameter.inc
@@ -5,17 +5,14 @@
 # Used by bash-my-aws functions to work with stdin and arguments.
 
 __bma_read_inputs() {
+  # combine STDIN with arguments
   echo $(__bma_read_stdin) $@ |
-    sed -E 's/\ +$//'         |
-    sed -E 's/^\ +//'
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
 }
 
 __bma_read_stdin() {
-  [[ -t 0 ]] ||
-    cat                  |
-      awk '{ print $1 }' |
-      tr '\n' ' '        |
-      sed 's/\ $//'
+  # return first item from each line of STDIN if not a terminal
+  [[ -t 0 ]] || awk '{ print $1 }'
 }
 
 __bma_read_resources() {

--- a/test/parameter-spec.sh
+++ b/test/parameter-spec.sh
@@ -11,13 +11,6 @@ describe "bma_read_stdin:" "$(
     expect "$(echo "a blah" | __bma_read_stdin)" to_be "a"
   )"
 
-  context "single word on multi line" "$(
-    expect "$(printf "a\nb" | __bma_read_stdin)" to_be "a b"
-  )"
-
-  context "multi word on a single line" "$(
-    expect "$(printf "a blah\nb else\n" | __bma_read_stdin)" to_be "a b"
-  )"
 )"
 
 describe "bma_read_inputs:" "$(


### PR DESCRIPTION
- Removed redundant cat
- Newline removal doesn't appear necessary
  You can choose to remove newlines when calling the function through quoting.

```
WITH_NEWLINES="$(__bma_read_inputs)"
WITHOUT_NEWLINES=$(__bma_read_inputs)
```

 ...or am I missing something?
