### PR TITLE
Correct join separator

### DIFF
--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -202,8 +202,8 @@ instance-ssh-details() {
       InstanceId,
       KeyName,
       (PublicIpAddress || PrivateIpAddress),
-      join(` `, [Tags[?Key==`Name`].Value][] || [`not-named`]),
-      join(` `, [Tags[?Key==`default-user`].Value][] || [``])
+      join(`" "`, [Tags[?Key==`Name`].Value][] || [`not-named`]),
+      join(`" "`, [Tags[?Key==`default-user`].Value][] || [``])
     ]
   '
   instances ${inputs} --query ${query}
@@ -345,7 +345,7 @@ instance-volumes() {
     Reservations[].Instances[][
       [
         InstanceId,
-        join(` `, BlockDeviceMappings[].Ebs[].VolumeId)
+        join(`" "`, BlockDeviceMappings[].Ebs[].VolumeId)
       ]
     ][]
   '


### PR DESCRIPTION
JMESPath backtick encloses a literal JSON expression.

Alternatively can escape this in bash eg: `join('\'' '\'',` which isn't as pretty