### PR TITLE
Support YAML stack-template output

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -330,7 +330,7 @@ stack-template() {
 
   aws cloudformation get-template   \
     --stack-name ${stack}           \
-    --query TemplateBody | jq --sort-keys .
+    --query TemplateBody | jq -r --sort-keys .
 }
 
 stack-outputs() {

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -330,7 +330,7 @@ stack-template() {
 
   aws cloudformation get-template   \
     --stack-name ${stack}           \
-    --query TemplateBody | jq -r --sort-keys .
+    --query TemplateBody | jq --raw-output --sort-keys .
 }
 
 stack-outputs() {


### PR DESCRIPTION
Currently prints out literal json string from response, eg: `"---\nAWSTemplateFormatVersion: 2010-09-09\nDescr...`