### PR TITLE
Re-Implement Cloudformation Functions (more secure and additional features)

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -126,8 +126,8 @@ stack-update() {
   if [ -n "$params" ]; then local parameters="--parameters file://$params"; fi
 
   local capabilities=''
-  local caps=$(_get_stack_capabilities $stack)
-  if [ "$caps" != "" ] ; then capabilities="--capabilities $caps" ; fi
+  local capabilities_value=$(_get_stack_capabilities $stack)
+  if [ "$capabilities_value" != "" ] ; then capabilities="--capabilities $capabilities_value" ; fi
 
   if aws cloudformation update-stack \
     --stack-name $stack              \

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -90,7 +90,7 @@ stack-create() {
   local capabilities=''
   local inputs_array=($inputs)
 
-  IFS='='
+  local IFS='='
   for index in "${inputs_array[@]}" ; do
     if [[ "$index" =~ ^\-\-arn=.* ]] ; then
       read arn_opt arn_arg <<< "$index" # ignore anything after

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -93,17 +93,18 @@ stack-create() {
     if [[ "$index" =~ ^\-\-arn=.* ]] ; then
       read arn_opt arn_arg <<< "$index" # ignore anything after option + arg
       arn="--role-arn $arn_arg"
-      inputs_array=("${inputs_array[@]:1}") # shift
     elif [[ "$index" =~ ^\-\-capabilities=.* ]] ; then
       read caps_opt caps_arg <<< "$index" # ignore anything after option + arg
       capabilities="--capabilities $caps_arg"
-      inputs_array=("${inputs_array[@]:1}") # shift
     fi
   done
 
-  if aws cloudformation create-stack                                   \
-    --stack-name $stack                                                \
-    --template-body file://$template $parameters $capabilities $arn    \
+  if aws cloudformation create-stack \
+    --stack-name $stack              \
+    --template-body file://$template \
+    $parameters                      \
+    $capabilities                    \
+    $arn                             \
     --disable-rollback
   then
     stack-tail $stack
@@ -126,7 +127,7 @@ stack-update() {
   if [ -n "$params" ]; then local parameters="--parameters file://$params"; fi
 
   local capabilities=''
-  local capabilities_value=$(_get_stack_capabilities $stack)
+  local capabilities_value=$(_stack_capabilities $stack)
   if [ "$capabilities_value" != "" ] ; then capabilities="--capabilities $capabilities_value" ; fi
 
   if aws cloudformation update-stack \
@@ -267,7 +268,7 @@ stack-status() {
   # return the current status of a stack
   local stack=$(__bma_read_inputs $@)
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
-  
+
   aws cloudformation describe-stacks                   \
     --stack-name ${stack}                              \
     --query "Stacks[][ [ StackName, StackStatus ] ][]" \
@@ -441,6 +442,9 @@ _stack_name_arg() {
   # Extract the stack name from the template file
   # Allows us to specify template name as stack name
   # File extension gets stripped off
+  if [[ $1 =~ ^\-\-arn=.*|^\-\-capabilities=.* ]] ; then
+    return 1
+  fi
   basename "$1" | sed 's/[.].*$//' # remove file extension
 }
 
@@ -456,7 +460,7 @@ _stack_template_arg() {
     fi
   fi
   if [[ $template =~ ^\-\-arn=.*|^\-\-capabilities=.* ]] ; then
-    __bma_usage "when supplying --arn or --capabilities you must first supply (at least) a stack name and a template file" && return 1
+    return 1
   fi
   echo $template
 }
@@ -471,10 +475,9 @@ _stack_params_arg() {
   fi
 }
 
-_get_stack_capabilities() {
+_stack_capabilities() {
   # determine what (if any) capabilities a given stack was deployed with
-  local capabilities=$(aws cloudformation describe-stacks --stack-name "$1" --query 'Stacks[].Capabilities' --output text)
-  echo $capabilities
+  aws cloudformation describe-stacks --stack-name "$1" --query 'Stacks[].Capabilities' --output text
 }
 
 ## vim: ft=sh

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -473,7 +473,7 @@ _stack_params_arg() {
 
 _get_stack_capabilities() {
   # determine what (if any) capabilities a given stack was deployed with
-  local capabilities=$(aws cloudformation describe-stacks --stack-name "$1" --output text | awk /CAPABILITIES/'{print $2}')
+  local capabilities=$(aws cloudformation describe-stacks --stack-name "$1" --query 'Stacks[].Capabilities' --output text)
   echo $capabilities
 }
 

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -75,7 +75,7 @@ stack-create() {
   # create a new stack
   local inputs=$(__bma_read_inputs $@)
   local stack=$(_stack_name_arg ${inputs})
-  [[ -z ${stack} ]] && __bma_usage "stack [template-file] [parameters-file] [--capabilities=VALUE | --role-arn=VALUE]" && return 1
+  [[ -z ${stack} ]] && __bma_usage "stack [template-file] [parameters-file] [--capabilities=OPTIONAL_VALUE] [--arn=OPTIONAL_VALUE]" && return 1
 
   local template=$(_stack_template_arg $inputs)
   if [ ! -f "$template" ]; then
@@ -104,15 +104,13 @@ stack-create() {
     fi
   done
 
-  echo "aws cloudformation create-stack --stack-name $stack --template-body file://$template $parameters $capabilities $arn"
-
-  #if aws cloudformation create-stack                                   \
-  #  --stack-name $stack                                                \
-  #  --template-body file://$template $parameters $capabilities $arn    \
-  #  --disable-rollback
-  #then
-  #  stack-tail $stack
-  #fi
+  if aws cloudformation create-stack                                   \
+    --stack-name $stack                                                \
+    --template-body file://$template $parameters $capabilities $arn    \
+    --disable-rollback
+  then
+    stack-tail $stack
+  fi
 }
 
 stack-update() {

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -39,7 +39,6 @@
 #
 # To make it fly we omit stacks with status of DELETE_COMPLETE
 stacks() {
-
   aws cloudformation list-stacks                      \
     --stack-status                                    \
       CREATE_COMPLETE                                 \
@@ -69,7 +68,6 @@ stack-cancel-update() {
   aws cloudformation cancel-update-stack --stack-name $stack
 }
 
-
 stack-create() {
   # type: action
   # create a new stack
@@ -89,16 +87,15 @@ stack-create() {
   local arn=''
   local capabilities=''
   local inputs_array=($inputs)
+  local IFS='=' # override default field separator in the scope of this function only
 
-  local IFS='='
   for index in "${inputs_array[@]}" ; do
     if [[ "$index" =~ ^\-\-arn=.* ]] ; then
-      read arn_opt arn_arg <<< "$index" # ignore anything after
+      read arn_opt arn_arg <<< "$index" # ignore anything after option + arg
       arn="--role-arn $arn_arg"
       inputs_array=("${inputs_array[@]:1}") # shift
-    fi
-    if [[ "$index" =~ ^\-\-capabilities=.* ]] ; then
-      read caps_opt caps_arg <<< "$index" # ignore anything after
+    elif [[ "$index" =~ ^\-\-capabilities=.* ]] ; then
+      read caps_opt caps_arg <<< "$index" # ignore anything after option + arg
       capabilities="--capabilities $caps_arg"
       inputs_array=("${inputs_array[@]:1}") # shift
     fi
@@ -124,11 +121,13 @@ stack-update() {
     echo "Could not find template (${template}). You can specify alternative template as second argument."
     return 1
   fi
+
   local params=$(_stack_params_arg $inputs)
   if [ -n "$params" ]; then local parameters="--parameters file://$params"; fi
 
-  local caps=$(aws cloudformation describe-stacks --stack-name "$stack" --output text | awk /CAPABILITIES/'{print $2}')
-  if [ "$caps" != "" ] ; then local capabilities="--capabilities $caps" ; fi
+  local capabilities=''
+  local caps=$(_get_stack_capabilities $stack)
+  if [ "$caps" != "" ] ; then capabilities="--capabilities $caps" ; fi
 
   if aws cloudformation update-stack \
     --stack-name $stack              \
@@ -456,6 +455,9 @@ _stack_template_arg() {
       template="${stack%-*}.json"
     fi
   fi
+  if [[ $template =~ ^\-\-arn=.*|^\-\-capabilities=.* ]] ; then
+    __bma_usage "when supplying --arn or --capabilities you must first supply (at least) a stack name and a template file" && return 1
+  fi
   echo $template
 }
 
@@ -467,6 +469,12 @@ _stack_params_arg() {
   if [ -f "${params}" ]; then
     echo $params
   fi
+}
+
+_get_stack_capabilities() {
+  # determine what (if any) capabilities a given stack was deployed with
+  local capabilities=$(aws cloudformation describe-stacks --stack-name "$1" --output text | awk /CAPABILITIES/'{print $2}')
+  echo $capabilities
 }
 
 ## vim: ft=sh

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -129,7 +129,7 @@ stack-update() {
 
   local capabilities=''
   local capabilities_value=$(_stack_capabilities $stack)
-  if [ "$capabilities_value" != "" ] ; then capabilities="--capabilities $capabilities_value" ; fi
+  [[ -z "${capabilities_value}" ]] || capabilities="--capabilities ${capabilities_value}"
 
   if aws cloudformation update-stack \
     --stack-name $stack              \

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -73,7 +73,7 @@ stack-create() {
   # create a new stack
   local inputs=$(__bma_read_inputs $@)
   local stack=$(_stack_name_arg ${inputs})
-  [[ -z ${stack} ]] && __bma_usage "stack [template-file] [parameters-file] [--capabilities=OPTIONAL_VALUE] [--arn=OPTIONAL_VALUE]" && return 1
+  [[ -z ${stack} ]] && __bma_usage "stack [template-file] [parameters-file] [--capabilities=OPTIONAL_VALUE] [--role-arn=OPTIONAL_VALUE]" && return 1
 
   local template=$(_stack_template_arg $inputs)
   if [ ! -f "$template" ]; then
@@ -90,7 +90,7 @@ stack-create() {
   local IFS='=' # override default field separator in the scope of this function only
 
   for index in "${inputs_array[@]}" ; do
-    if [[ "$index" =~ ^\-\-arn=.* ]] ; then
+    if [[ "$index" =~ ^\-\-role\-arn=.* ]] ; then
       read arn_opt arn_arg <<< "$index" # ignore anything after option + arg
       arn="--role-arn $arn_arg"
     elif [[ "$index" =~ ^\-\-capabilities=.* ]] ; then
@@ -442,7 +442,7 @@ _stack_name_arg() {
   # Extract the stack name from the template file
   # Allows us to specify template name as stack name
   # File extension gets stripped off
-  if [[ $1 =~ ^\-\-arn=.*|^\-\-capabilities=.* ]] ; then
+  if [[ $1 =~ ^\-\-role\-arn=.*|^\-\-capabilities=.* ]] ; then
     return 1
   fi
   basename "$1" | sed 's/[.].*$//' # remove file extension
@@ -459,7 +459,7 @@ _stack_template_arg() {
       template="${stack%-*}.json"
     fi
   fi
-  if [[ $template =~ ^\-\-arn=.*|^\-\-capabilities=.* ]] ; then
+  if [[ $template =~ ^\-\-role\-arn=.*|^\-\-capabilities=.* ]] ; then
     return 1
   fi
   echo $template

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -75,24 +75,44 @@ stack-create() {
   # create a new stack
   local inputs=$(__bma_read_inputs $@)
   local stack=$(_stack_name_arg ${inputs})
-  [[ -z ${stack} ]] && __bma_usage "stack [template-file] [parameters-file]" && return 1
+  [[ -z ${stack} ]] && __bma_usage "stack [template-file] [parameters-file] [--capabilities=VALUE | --role-arn=VALUE]" && return 1
 
   local template=$(_stack_template_arg $inputs)
   if [ ! -f "$template" ]; then
     echo "Could not find template (${template}). You can specify alternative template as second argument."
     return 1
   fi
+
   local params=$(_stack_params_arg $inputs)
   if [ -n "$params" ]; then local parameters="--parameters file://$params"; fi
 
-  if aws cloudformation create-stack             \
-    --stack-name $stack                          \
-    --template-body file://$template $parameters \
-    --capabilities CAPABILITY_NAMED_IAM          \
-    --disable-rollback
-  then
-    stack-tail $stack
-  fi
+  local arn=''
+  local capabilities=''
+  local inputs_array=($inputs)
+
+  IFS='='
+  for index in "${inputs_array[@]}" ; do
+    if [[ "$index" =~ ^\-\-arn=.* ]] ; then
+      read arn_opt arn_arg <<< "$index" # ignore anything after
+      arn="--role-arn $arn_arg"
+      inputs_array=("${inputs_array[@]:1}") # shift
+    fi
+    if [[ "$index" =~ ^\-\-capabilities=.* ]] ; then
+      read caps_opt caps_arg <<< "$index" # ignore anything after
+      capabilities="--capabilities $caps_arg"
+      inputs_array=("${inputs_array[@]:1}") # shift
+    fi
+  done
+
+  echo "aws cloudformation create-stack --stack-name $stack --template-body file://$template $parameters $capabilities $arn"
+
+  #if aws cloudformation create-stack                                   \
+  #  --stack-name $stack                                                \
+  #  --template-body file://$template $parameters $capabilities $arn    \
+  #  --disable-rollback
+  #then
+  #  stack-tail $stack
+  #fi
 }
 
 stack-update() {
@@ -109,11 +129,14 @@ stack-update() {
   local params=$(_stack_params_arg $inputs)
   if [ -n "$params" ]; then local parameters="--parameters file://$params"; fi
 
+  local caps=$(aws cloudformation describe-stacks --stack-name "$stack" --output text | awk /CAPABILITIES/'{print $2}')
+  if [ "$caps" != "" ] ; then local capabilities="--capabilities $caps" ; fi
+
   if aws cloudformation update-stack \
     --stack-name $stack              \
     --template-body file://$template \
     $parameters                      \
-    --capabilities CAPABILITY_NAMED_IAM
+    $capabilities
   then
     stack-tail $stack
   fi
@@ -207,7 +230,7 @@ stack-resources() {
   aws cloudformation describe-stack-resources                       \
     --stack-name ${stack}                                           \
     --query "StackResources[].[ PhysicalResourceId, ResourceType ]" \
-    --output text                                                   
+    --output text
 }
 
 stack-asgs() {

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -99,6 +99,7 @@ stack-create() {
     fi
   done
 
+  unset IFS # to prevent it from breaking things later
   if aws cloudformation create-stack \
     --stack-name $stack              \
     --template-body file://$template \


### PR DESCRIPTION
This PR makes the following changes

* Adds an `--capabilities` option to `stack-create`, allowing the user to define what (if any) capabilities the stack is created with. No longer will it always use the excessive `CAPABILITY_NAMED_IAM`
* Adds an `--role-arn` option to allow the user to supply a CloudFormation Service Role
* Re-implements `stack-update` to detect the capabilities a stack was deployed with and act accordingly, no longer will it always use the excessive `CAPABILITY_NAMED_IAM`
* Minor formatting cleanup
* Addition of relevant error handling

I have tested it fairly extensively and the changes work and preserve all existing interfaces.

The specifics of how/why I implemented this change (and why, for example I didn't use `getopts` for my option parser) can be discussed if desired...