### PR TITLE
image-functions: images() lists AMIs

### DIFF
--- a/lib/image-functions
+++ b/lib/image-functions
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# image-functions
+#
+# List Amazon Machine Images
+
+# Usage: images [owner] [image-id] [image-id]...
+#
+# owner defaults to `self` or can one or more of:
+#   - an AWS_ACCOUNT_ID  (e.g. 1234567890)
+#   - an AWS_OWNER_ALIAS (amazon, amazon-marketplace, microsoft)
+# image_id can be one or more AMIs
+#
+images() {
+  # Trialing a funky new way of grabbing resource ids from input
+  # As normal, you can pipe resource ids in as first token on each line
+  # We treat all args that don't start with ami- as owner identifiers
+  local inputs=$(__bma_read_inputs $@) 
+  local image_ids=$(echo -n "$inputs" | tr ' ' '\n' | grep ami- | tr '\n' ' ')
+  local owners=$(echo -n "$inputs" | tr ' ' '\n' | grep -v ami- | tr '\n' ' ')
+
+  # Trialing a new pattern for output - putting the Name at the end
+  # This is more like the output of `ls -la`
+  # Pro: Preceding fields tend to be of the same length
+  # Pro: Easier for eyes to scan final column for names(?)
+  # Con: Using this pattern for instances() would put name past 80 char point
+  # Con: Migrating instances() to this output is A Big Change (not made lightly)
+  aws ec2 describe-images                                            \
+    $([[ -n "$image_ids" ]] && echo --image-ids "${image_ids}")  \
+    $([[ -n "$owners" || -z "$image_ids" ]] && echo --owners "${owners:-self}") \
+    --query "
+      sort_by(Images, &CreationDate)[].[
+        ImageId,
+        CreationDate,
+        OwnerId,
+        Name
+      ]"                                                               \
+    --output text |
+    column -s$'\t' -t
+}

--- a/lib/image-functions
+++ b/lib/image-functions
@@ -38,3 +38,22 @@ images() {
     --output text |
     column -s$'\t' -t
 }
+
+
+image-deregister() {
+  local image_ids=$(__bma_read_inputs $@)
+  [[ -z "${image_ids}" ]] && __bma_usage "image_id" && return 1
+
+  local image_id
+  for image_id in $image_ids; do
+    aws ec2 deregister-image --image-id "$image_id"
+  done
+}
+
+# List block devices
+# $ aws ec2 describe-images --image-ids ami-5f5b883d --query Images[].BlockDeviceMappings[].Ebs.SnapshotId --output text
+# snap-0f4773dcf6511308a
+
+
+# List snapshots
+# aws ec2 describe-snapshots --owner-ids self


### PR DESCRIPTION
[For review - may still change]

Usage: images [owner] [image-id] [image-id]...

owner defaults to `self` or can one or more of:
  - an AWS_ACCOUNT_ID  (e.g. 1234567890)
  - an AWS_OWNER_ALIAS (amazon, amazon-marketplace, microsoft)
image_id can be one or more AMIs

example usage:
```
# no AMI's in this account
$ images

# List AMIs shared from Fobar account to this account
$ images 1234567890 | head -5
ami-11111111  2015-09-08T03:24:17.000Z  1234567890  example-app-3.123-1-ebs
ami-22222222  2015-09-08T06:27:17.000Z  1234567890  example-app-92
ami-33333333  2015-09-08T06:46:07.000Z  1234567890  example-app-93
ami-44444444  2015-09-08T07:18:27.000Z  1234567890  example-app-95
ami-55555555  2015-09-08T07:38:32.000Z  1234567890  example-app-96
```