### PR TITLE
Re-columnise stack-asgs

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -237,7 +237,9 @@ stack-resources() {
 stack-asgs() {
   # type: detail
   # return the autoscaling groups managed by a stack
-  stack-resources $@ | grep AWS::AutoScaling::AutoScalingGroup
+  stack-resources $@                      | 
+  grep AWS::AutoScaling::AutoScalingGroup |
+  column -t
 }
 
 stack-asg-instances() {


### PR DESCRIPTION
After filtering out other resource types we can tidy up columns
by reducing whitespace