### PR TITLE
stack-tag() stack-tag-apply() stack-tag-delete()

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -34,6 +34,17 @@
 # And don't forget, these naming conventions are completely optional.
 ##
 
+stack-arn() {
+  local stacks=$(__bma_read_inputs $@)
+  [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
+  local stack
+  for stack in $stacks; do
+    aws cloudformation describe-stacks \
+      --stack-name "$stack"            \
+      --query "Stacks[].StackId" \
+      --output text
+  done
+}
 
 # List CF stacks
 #
@@ -220,7 +231,7 @@ stack-events() {
         ResourceType,
         ResourceStatus
       ]"                                   \
-    --output table); then 
+    --output table); then
     echo "$output" | uniq -u
   else
     return $?
@@ -244,7 +255,7 @@ stack-resources() {
 stack-asgs() {
   # type: detail
   # return the autoscaling groups managed by a stack
-  stack-resources $@                      | 
+  stack-resources $@                      |
   grep AWS::AutoScaling::AutoScalingGroup |
   column -t
 }
@@ -302,19 +313,120 @@ stack-status() {
   done
 }
 
-stack-tags() {
-  # return the tags applied to a stack
+stack-tag() {
+  # return a selected stack tag
+  local tag=$1
+  shift 1
+  [[ -z "${tag}" ]] && __bma_usage "tag-key stack [stack]" && return 1
   local stacks=$(__bma_read_inputs $@)
-  [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
+  [[ -z ${stacks} && -t 0 ]] && __bma_usage "tag-key stack [stack]" && return 1
   local stack
   for stack in $stacks; do
-    aws cloudformation describe-stacks                                      \
-      --stack-name "${stack}"                                               \
+    aws cloudformation describe-stacks                                       \
+      --stack-name "${stack}"                                                \
       --query "Stacks[].[
-                 StackName, 
-                 join(' ', [Tags[$tag_filter].[join('=',[Key,Value])][]][])
-               ]"                                                           \
+                 StackName,
+                 join(' ', [Tags[?Key=='$tag'].[join('=',[Key,Value])][]][])
+               ]"                                                            \
       --output text
+  done
+}
+
+stack-tags() {
+  # return all stack tags
+  local stacks=$(__bma_read_inputs $@)
+  [[ -z ${stacks} && -t 0 ]] && __bma_usage "stack [stack]" && return 1
+  local stack
+  for stack in $stacks; do
+    aws cloudformation describe-stacks                                  \
+      --stack-name "${stack}"                                           \
+      --query "Stacks[].[
+                 StackName,
+                 join(' ', [Tags[].[join('=',[Key,Value])][]][])
+               ]"                                                       \
+      --output text
+  done
+}
+
+stack-tag-apply() {
+  # apply a stack tag
+  local tag_key=$1
+  local tag_value=$2
+  shift 2
+  local usage_msg="tag-key tag-value stack [stack]"
+  [[ -z "${tag_key}" ]]    && __bma_usage $usage_msg && return 1
+  [[ -z "${tag_value}" ]] && __bma_usage $usage_msg && return 1
+
+  local stacks=$(__bma_read_inputs $@)
+  [[ -z "${stacks}" && -t 0 ]] && __bma_usage $usage_msg && return 1
+
+  local stack
+  for stack in $stacks; do
+
+    # XXX deal with tagging service failing
+    local tags=$(aws cloudformation describe-stacks \
+           --stack-name "$stack"                    \
+           --query "[
+                  [{Key:'$tag_key', Value:'$tag_value'}],
+                  Stacks[].Tags[?Key != '$tag_key'][]
+                ][]")
+
+    local parameters=$(aws cloudformation describe-stacks \
+           --stack-name "$stack"                          \
+           --query '
+             Stacks[].Parameters[].{
+               ParameterKey: ParameterKey,
+               UsePreviousValue: `true`
+           }')
+
+    local capabilities=''
+    local capabilities_value=$(_stack_capabilities $stack)
+    [[ -z "${capabilities_value}" ]] || capabilities="--capabilities ${capabilities_value}"
+
+     $([[ -n $DRY_RUN ]] && echo echo) aws cloudformation update-stack \
+      --stack-name "$stack"         \
+      --use-previous-template       \
+      --parameters "$parameters"    \
+      --tags "$tags"                \
+      $capabilities                 \
+      --query StackId               \
+      --output text
+  done
+}
+
+stack-tag-delete() {
+  # delete a stack tag
+  local tag_key=$1
+  shift 1
+  [[ -z "${tag_key}" ]] && __bma_usage "tag-key stack [stack]" && return 1
+
+  local stacks=$(__bma_read_inputs $@)
+  [[ -z "${stacks}" ]] && __bma_usage "tag-key stack [stack]" && return 1
+
+  local stack
+  for stack in $stacks; do
+
+    # XXX deal with tagging service failing
+    local tags=$(aws cloudformation describe-stacks \
+           --stack-name "$stack"                    \
+           --query "[
+                  Stacks[].Tags[?Key != '$tag_key'][]
+                ][]")
+
+    local parameters=$(aws cloudformation describe-stacks \
+           --stack-name "$stack"                          \
+           --query '
+             Stacks[].Parameters[].{
+               ParameterKey: ParameterKey,
+               UsePreviousValue: `true`
+           }')
+
+    aws cloudformation update-stack \
+      --stack-name "$stack"         \
+      --use-previous-template       \
+      --parameters "$parameters"    \
+      --tags "$tags"
+
   done
 }
 
@@ -427,7 +539,7 @@ _stack_diff_template() {
     --label stack \
       <(aws cloudformation get-template  \
           --stack-name $stack            \
-          --query TemplateBody           | 
+          --query TemplateBody           |
         jq --sort-keys .)                \
      --label $template                   \
        <(jq --sort-keys . $template)
@@ -470,7 +582,7 @@ _stack_diff_params() {
     --label params                               \
       <(aws cloudformation describe-stacks       \
           --query "Stacks[].Parameters[]"        \
-          --stack-name $stack                    | 
+          --stack-name $stack                    |
         jq --sort-keys 'sort_by(.ParameterKey)') \
     --label $params                              \
       <(jq --sort-keys 'sort_by(.ParameterKey)' $params)


### PR DESCRIPTION
stack-tag() returns the value of a named stack tag
stack-tag-apply() creates or updates a named stack-tag
stack-tag-delete() removes a stack-tag

** Warning **
Note that when updating stack tags, you need to specify all of the
ones you wish to exist. I believe they are managed stored within
the CloudFormation service, not the tagging service but this has
not been confirmed.

A known problem with making assumptions about tags based on the tags
returned by queries on resources like EC2 Instances is that if the
tagging service fails, you may get a list of instances but not their
tags. If this were the case with CloudFormation Stack Tags then the
stack-tag-apply() and stack-tag-delete() functions could remove
all tags in the case of a failure in tagging service.

I'll continue to attempt to confirm whether this risk exists and
deal with it if my suspicion that stack-tags are not promne to this
problem is disproved.