### PR TITLE
vpc-subnets() output sorted by name field

### DIFF
--- a/lib/vpc-functions
+++ b/lib/vpc-functions
@@ -105,7 +105,8 @@ vpc-subnets(){
         CidrBlock,
         VpcId
       ]"                                                            \
-      --output text
+      --output text                                                 |
+    sort -k 2 # sort by name as resource-id is pretty random
   done | column -s$'\t' -t
 }
 


### PR DESCRIPTION
Subnet names are more likely to be visually scanned by user than
resource-id