### PR TITLE
Breaking change: stack-tags() returns JSON for single stack

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -331,23 +331,6 @@ stack-tag() {
   done
 }
 
-stack-tags() {
-  # return all stack tags
-  local stacks=$(__bma_read_inputs $@)
-
-  [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
-  local stack
-  for stack in $stacks; do
-    aws cloudformation describe-stacks                                  \
-      --stack-name "${stack}"                                           \
-      --query "Stacks[].[
-                 StackName,
-                 join(' ', [Tags[].[join('=',[Key,Value])][]][])
-               ]"                                                       \
-      --output text
-  done
-}
-
 stack-tag-apply() {
   # apply a stack tag
   local tag_key=$1
@@ -464,15 +447,50 @@ stack-tail() {
 }
 
 stack-template() {
-  # type: detail
   # return the template applied to a stack
   local inputs=$(__bma_read_inputs $@)
   local stack=$(_stack_name_arg ${inputs})
 
+  [[ -z ${stack} ]] && __bma_usage "stack" && return 1
+
   aws cloudformation get-template   \
-    --stack-name ${stack}           \
-    --query TemplateBody | jq --raw-output --sort-keys .
+    --stack-name "$stack"           \
+    --query TemplateBody            |
+  jq --raw-output --sort-keys .
 }
+
+stack-tags() {
+  # return the stack-tags applied to a stack
+  local inputs=$(__bma_read_inputs $@)
+  local stack=$(_stack_name_arg ${inputs})
+
+  [[ -z ${stack} ]] && __bma_usage "stack" && return 1
+
+  aws cloudformation describe-stacks \
+    --stack-name "$stack"            \
+    --query 'Stacks[0].Tags'         |
+  jq --sort-keys .
+
+}
+
+stack-tags-text() {
+  # return all stack tags on a single line
+  local stacks=$(__bma_read_inputs $@)
+
+  [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
+  local stack
+  for stack in $stacks; do
+    aws cloudformation describe-stacks                                  \
+      --stack-name "${stack}"                                           \
+      --query "Stacks[].[
+                 StackName,
+                 join(' ', [Tags[].[join('=',[Key,Value])][]][])
+               ]"                                                       \
+      --output text
+  done
+}
+
+
 
 stack-outputs() {
   # type: detail


### PR DESCRIPTION
This change brings makes stack-tags() behave more like:
- stack-template()
- stack-parameters()

They provide a file that will be accepted as input to AWSCLI
when creating/updating stacks.

stack-tags-text() provides old behaviour of stack-tags()
- one line of text per stack with all tags (key=value)

Note that stack-tag() function may be more useful for checking
value of a specific tag:

```
$ stacks | stack-tag costcode
example-stack 1000
another-stack
yetmore-stack 1001
```