### PR TITLE
Added --capabilities to stack-recreate()

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -187,13 +187,20 @@ stack-recreate() {
   local stack=$(_stack_name_arg ${inputs})
   [[ -z "${stack}" ]] && __bma_usage "stack" && return 1
 
+  local capabilities=''
+  local capabilities_value=$(_stack_capabilities $stack)
+  [[ -z "${capabilities_value}" ]] || capabilities="--capabilities=${capabilities_value}"
+
   local tmpdir=`mktemp -d /tmp/bash-my-aws.XXXX`
   cd $tmpdir
   stack-template $stack > "${stack}.template"
   stack-parameters $stack > "${stack}-params.json"
   stack-delete $stack
-  stack-create $stack "${stack}.template" "${stack}-params.json"
-  # rm -fr $tmpdir
+  stack-create $stack \
+              "${stack}.template" \
+              "${stack}-params.json" \
+              $capabilities
+  #rm -fr $tmpdir
 }
 
 stack-failure() {


### PR DESCRIPTION
Hi, very small addition to stack-recreate(), added in _stack_capabilities cos with out it the function failed when re-creating a stack with it

`An error occurred (InsufficientCapabilitiesException) when calling the CreateStack operation: Requires capabilities : [CAPABILITY_NAMED_IAM]`

Now the odds are high, that I've missed something so provide any feedback 😂 