### PR TITLE
Order instances() output by LaunchTime

### DIFF
--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -20,8 +20,9 @@ instances() {
         Placement.AvailabilityZone,
         VpcId
       ]"                                                               \
-    --output text |
-    column -s$'\t' -t
+    --output text                      |
+  sort --ignore-leading-blanks --key=6 |
+  column -s$'\t' -t
 }
 
 instance-asg() {


### PR DESCRIPTION
I'm often interested in the instance I recently started.
The other alternative is instance name. If this is your preference,
pipe output through `sort -k 5` (and perhaps create an alias).