### PR TITLE
List functions (like `stacks`) allow filtering.

### DIFF
--- a/lib/asg-functions
+++ b/lib/asg-functions
@@ -3,8 +3,8 @@
 # asg-functions
 
 asgs() {
-  # returns instance id's and the name tag.
-  local asg_names=$(__bma_read_inputs $@)
+  local asg_names=$(__bma_read_inputs)
+  local filters=$(__bma_read_filters $@)
 
   aws autoscaling describe-auto-scaling-groups                             \
     $([[ -n ${asg_names} ]] && echo --auto-scaling-group-names $asg_names) \
@@ -13,7 +13,8 @@ asgs() {
         AutoScalingGroupName,
         [Tags[?Key=='Name'].Value][0][0]
       ]"                                                                   \
-    --output text                                                          |
+    --output text    |
+  grep -E "$filters" |
   column -s$'\t' -t 
 }
 

--- a/lib/cloudtrail-functions
+++ b/lib/cloudtrail-functions
@@ -3,6 +3,9 @@
 # cloudtrail-functions
 
 function cloudtrails() {
+
+  local filters=$(__bma_read_filters $@)
+
   aws cloudtrail describe-trails --query " \
     trailList[].[
       Name, 
@@ -11,7 +14,9 @@ function cloudtrails() {
       join('=', ['IsMultiRegionTrail', to_string(IsMultiRegionTrail)]), 
       join('=', ['IncludeGlobalServiceEvents', to_string(IncludeGlobalServiceEvents)])
     ]
-  " \
-  --output text
+    " \
+    --output text    |
+  grep -E "$filters"
+
 }
 

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -4,13 +4,15 @@
 
 elbs() {
   # returns a list of ELBS
-  local elb_names=$(__bma_read_inputs $@)
+  local elb_names=$(__bma_read_inputs)
+  local filters=$(__bma_read_filters $@)
 
   aws elb describe-load-balancers                                     \
     $([[ -n ${elb_names} ]] && echo --load-balancer-names $elb_names) \
     --query "LoadBalancerDescriptions[][ LoadBalancerName ]"          \
-    --output text                                                     |
-  sort                                                                |
+    --output text    |
+  grep -E "$filters" |
+  sort               |
   column -s$'\t' -t
 }
 

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -5,7 +5,8 @@
 # List, run, start, stop and ssh to Amazon AWS EC2 instances
 
 instances() {
-  local instance_ids=$(__bma_read_inputs $@)
+  local instance_ids=$(__bma_read_inputs)
+  local filters=$(__bma_read_filters $@)
 
   aws ec2 describe-instances                                            \
     $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
@@ -20,8 +21,9 @@ instances() {
         Placement.AvailabilityZone,
         VpcId
       ]"                                                               \
-    --output text |
-    column -s$'\t' -t
+    --output text    |
+  grep -E "$filters" |
+  column -s$'\t' -t
 }
 
 instance-asg() {

--- a/lib/s3-functions
+++ b/lib/s3-functions
@@ -3,9 +3,12 @@
 # s3-functions
 
 buckets() {
+  local filters=$(__bma_read_filters $@)
+
   aws s3api list-buckets \
     --query "Buckets[].[Name, CreationDate]" \
-    --output text | 
+    --output text    |
+  grep -E "$filters" |
   column -t
 }
 

--- a/lib/shared-functions
+++ b/lib/shared-functions
@@ -18,6 +18,13 @@ __bma_read_stdin() {
       sed 's/\ $//'
 }
 
+# Construct a string to be passed to `grep -E`
+__bma_read_filters() {
+  local IFS_SAVED="$IFS"; IFS=$'|'
+  printf "$*"
+  IFS=$IFS_SAVED
+}
+
 __bma_error() {
   echo "ERROR: $@" > /dev/stderr
   return 1

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -34,23 +34,14 @@
 # And don't forget, these naming conventions are completely optional.
 ##
 
-stack-arn() {
-  local stacks=$(__bma_read_inputs $@)
-  [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
-  local stack
-  for stack in $stacks; do
-    aws cloudformation describe-stacks \
-      --stack-name "$stack"            \
-      --query "Stacks[].StackId" \
-      --output text
-  done
-}
-
 # List CF stacks
 #
 # To make it fly we omit stacks with status of DELETE_COMPLETE
 # Output sorted by CreationTime
 stacks() {
+
+  local filters=$(__bma_read_filters $@)
+
   aws cloudformation list-stacks                      \
     --stack-status                                    \
       CREATE_COMPLETE                                 \
@@ -74,9 +65,23 @@ stacks() {
                CreationTime,
                LastUpdatedTime
              ]"                                       \
-    --output text                                     |
-  sort -b -k 3                                        |
+    --output text    |
+  grep -E "$filters" |
+  sort -b -k 3       |
   column -s$'\t' -t
+}
+
+
+stack-arn() {
+  local stacks=$(__bma_read_inputs $@)
+  [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
+  local stack
+  for stack in $stacks; do
+    aws cloudformation describe-stacks \
+      --stack-name "$stack"            \
+      --query "Stacks[].StackId" \
+      --output text
+  done
 }
 
 stack-cancel-update() {

--- a/lib/vpc-functions
+++ b/lib/vpc-functions
@@ -3,7 +3,8 @@
 # vpc-functions
 
 vpcs() {
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$(__bma_read_inputs)"
+  local filters=$(__bma_read_filters $@)
 
   aws ec2 describe-vpcs \
     $([[ -n ${vpc_ids} ]] && echo --vpc-ids ${vpc_ids})     \
@@ -15,8 +16,9 @@ vpcs() {
       Tags[?Key==`aws:cloudformation:stack-name`].Value, 
       Tags[?Key==`version`].Value][]
       ][]'                                                  \
-    --output text                                           |
-    column -s$'\t' -t
+    --output text    |
+  grep -E "$filters" |
+  column -s$'\t' -t
 }
 
 vpc-lambda-functions(){


### PR DESCRIPTION
This is big and I'm very excited about it but it's a non breaking change.

I sat on it for a long time because I want to maintain interface
uniformity between functions. Last night I had a breakthrough while
walking the dogs.

Providing string(s) to grep for as args instead of piping through
the grep command offer two main benefits:

- less keystrokes: don't need to type `| grep`
- neater output:  it's run through `column` after filtering

I like short names. Sometimes people use long resource names which can
blow out the width of columns when listing them. If you keep the names
of your resources short then why should your view be tainted by the
verbose nomenclature of others? Now it needn't be.

**Before - looks terrible!**
```
$ stacks | grep web
example-ui-s3-website                                               UPDATE_COMPLETE           2018-01-23T04:19:56.776Z  2018-07-16T01:22:06.042Z
example-express-web                                                      UPDATE_COMPLETE           2018-02-28T01:01:45.098Z  2018-07-03T23:32:47.671Z
example-web-deploy-role                                      UPDATE_COMPLETE           2018-03-01T04:29:11.714Z  2018-06-20T05:56:12.313Z
```

In the example above there are huge gaps because some lines that were
removed by `grep` had very long CloudFormation stack names.

Provding the string(s) to filter on as arguments allows the function to
grep *before* feeding the output through `column`.

**After - so much better!**
```
$ stacks web
example-ui-s3-website    UPDATE_COMPLETE  2018-01-23T04:19:56.776Z  2018-07-16T01:22:06.042Z
example-express-web      UPDATE_COMPLETE  2018-02-28T01:01:45.098Z  2018-07-03T23:32:47.671Z
example-web-deploy-role  UPDATE_COMPLETE  2018-03-01T04:29:11.714Z  2018-06-20T05:56:12.313Z
```

Existing uses of these commands will still work however any arguments
provided to them will be used to grep output.

In the case of a function like `instances` that previously accepted
instance-ids as arguments, these will now be used to filter output
on the client machine rather than passing them to the awscli request.
I don't imagine this will often cause a performance impact - you would
need to have a lot of instances and/or a slow network connection - but
the old behaviour can still be achieved by piping the resources in as
you could do previously.