### PR TITLE
Add function to read single char that works in bash and zsh

### DIFF
--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -267,7 +267,8 @@ instance-terminate() {
   instances "$instance_ids"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
-  read -p "Are you sure you want to continue? " -n 1 -r
+  printf "Are you sure you want to continue? "
+  __bma_read_char_stdin REPLY
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then
@@ -296,7 +297,8 @@ instance-termination-protection-disable() {
   instances "$instance_ids"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
-  read -p "Are you sure you want to continue? " -n 1 -r
+  printf "Are you sure you want to continue? "
+  __bma_read_char_stdin REPLY
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then
@@ -317,7 +319,8 @@ instance-termination-protection-enable() {
   instances "$instance_ids"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
-  read -p "Are you sure you want to continue? " -n 1 -r
+  printf "Are you sure you want to continue? "
+  __bma_read_char_stdin REPLY
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then

--- a/lib/keypair-functions
+++ b/lib/keypair-functions
@@ -34,8 +34,9 @@ keypair-delete(){
   echo "You are about to delete the following EC2 SSH KeyPairs:"
   echo "$keypairs" | tr ' ' "\n"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
-  local regex_yes="^[Yy]$"
-  read -p "Are you sure you want to continue? " -n 1 -r
+  local regex_yes="^[Yy]$"z
+  printf "Are you sure you want to continue? "
+  __bma_read_char_stdin REPLY
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then

--- a/lib/keypair-functions
+++ b/lib/keypair-functions
@@ -34,7 +34,7 @@ keypair-delete(){
   echo "You are about to delete the following EC2 SSH KeyPairs:"
   echo "$keypairs" | tr ' ' "\n"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
-  local regex_yes="^[Yy]$"z
+  local regex_yes="^[Yy]$"
   printf "Are you sure you want to continue? "
   __bma_read_char_stdin REPLY
   echo

--- a/lib/shared-functions
+++ b/lib/shared-functions
@@ -4,6 +4,17 @@
 #
 # Used by bash-my-aws functions to work with stdin and arguments.
 
+__bma_read_char_stdin() {
+  if [ -t 0 ]; then
+    saved_tty_settings=$(stty -g)
+    stty -icanon min 1 time 0
+    eval "$1=\$(dd bs=1 count=1 2> /dev/null)"
+    stty "$saved_tty_settings"
+  else
+    eval "$1=n"
+  fi
+}
+
 __bma_read_inputs() {
   echo $(__bma_read_stdin) $@ |
     sed -E 's/\ +$//'         |

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -176,7 +176,8 @@ stack-delete() {
   echo "$stacks" | tr ' ' "\n"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
-  read -p "Are you sure you want to continue? " -n 1 -r
+  printf "Are you sure you want to continue? "
+  __bma_read_char_stdin REPLY
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then


### PR DESCRIPTION
# What

- add helper function for reading a single character from user 

# How

- found a way to read the input which is posix-compliant
- see : <https://unix.stackexchange.com/questions/464930/can-i-read-a-single-character-from-stdin-in-posix-shell>
- replaced all `read -p` to use new function `__bma_read_char_stdin`

# Why

- broke on zsh ( for me when i wanted to delete some stacks ) o(╥﹏╥)
- apparently the `-p` flag in zsh and bash does different things 
```sh
❯ keypair-delete test-key
You are about to delete the following EC2 SSH KeyPairs:
test-key
keypair-delete:read:8: -p: no coprocess
```  


